### PR TITLE
csvにscoreを保存する & 全体評価用スクリプト追加

### DIFF
--- a/lcb_runner/runner/main.py
+++ b/lcb_runner/runner/main.py
@@ -14,6 +14,49 @@ from lcb_runner.runner.scenario_router import (
     get_metrics,
 )
 
+import csv, os
+
+def update_scores_row(all_result_path: str, model: str, col_index: int, task: str, score, overwrite_header: bool = False):
+    if col_index < 1:
+        raise ValueError("col_index は 1 以上を指定してください（1 列目は 'model'）。")
+
+    header, rows = [], []
+    if os.path.exists(all_result_path):
+        with open(all_result_path, "r", newline="", encoding="utf-8") as f:
+            r = list(csv.reader(f))
+            if r:
+                header, rows = r[0], r[1:]
+    if not header:
+        header = []
+    if len(header) < col_index:
+        header.extend([""] * (col_index - len(header)))
+    header[0] = "model"
+    tgt = col_index - 1  # 0-based index
+    if header[tgt] in ("", task) or overwrite_header:
+        header[tgt] = task
+    else:
+        print(f"This column {col_index} is already existed! {header[tgt]}")
+    row = None
+    for r in rows:
+        if r and r[0] == model:
+            row = r
+            break
+    if row is None:
+        row = [""]
+        row[0] = model
+        rows.append(row)
+    if len(row) < len(header):
+        row.extend([""] * (len(header) - len(row)))
+    row[tgt] = str(score)
+    for r in rows:
+        if len(r) < len(header):
+            r.extend([""] * (len(header) - len(r)))
+    os.makedirs(os.path.dirname(all_result_path) or ".", exist_ok=True)
+    with open(all_result_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(header)
+        w.writerows(rows)
+
 
 def main():
     args = get_args()
@@ -215,6 +258,8 @@ def main():
             ]
 
         save_eval_results = old_eval_all_results + save_eval_results
+        if args.all_result_csv:
+            update_scores_row(args.all_result_csv, args.model, 4, "LiveCodeBench", f"{metrics[0]['pass@1']:.3f}")
 
         with open(eval_file, "w") as f:
             json.dump(metrics, f, indent=4)

--- a/lcb_runner/runner/parser.py
+++ b/lcb_runner/runner/parser.py
@@ -137,6 +137,12 @@ def get_args():
         default=None,
         help="Path to livecodebench dataset",
     )
+    parser.add_argument(
+        "--all_result_csv",
+        type=str,
+        default=None,
+    )
+
 
     args = parser.parse_args()
 

--- a/scripts/evaluate_rt_HG_for_all.sh
+++ b/scripts/evaluate_rt_HG_for_all.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#PBS -q rt_HG
+#PBS -N livecodebench
+#PBS -l select=1
+#PBS -l walltime=1:00:00
+#PBS -j oe
+#PBS -m n
+#PBS -koed
+#PBS -V
+#PBS -o outputs/
+
+set -e
+cd "$PBS_O_WORKDIR/LiveCodeBench"
+
+echo "Nodes allocated to this job:"
+cat $PBS_NODEFILE
+
+# environment variables
+export TMP="/groups/gag51395/fujii/tmp"
+export TMP_DIR="/groups/gag51395/fujii/tmp"
+export HF_HOME="/groups/gag51395/fujii/hf_cache"
+
+source .venv/bin/activate
+
+export CUDA_VISIBLE_DEVICES=0
+export TOKENIZERS_PARALLELISM=false
+python -m lcb_runner.runner.main \
+  --model $MODEL \
+  --scenario codegeneration \
+  --evaluate \
+  --release_version release_v6 \
+  --dataset-path "/groups/gcg51558/datasets/eval/code_generation_lite" \
+  --all_result_csv $RESULT_CSV
+
+


### PR DESCRIPTION
他のスコアも含めて同じcsvに保存できるように対応
model, , , LiveCodeBench, ...　という形式のcsvを作成 or 追加記入
--all_result_csv 引数を追加すると使用できます
また，bigcodebench.evaluateを変更後のものを使うために
```
python -m lcb_runner.runner.main \
  --model $MODEL \
  --scenario codegeneration \
  --evaluate \
  --release_version release_v6 \
  --dataset-path "/groups/gcg51558/datasets/eval/code_generation_lite" \
  --all_result_csv $RESULT_CSV
```

このように保存されます
```
model,,,LiveCodeBench
tokyotech-llm/Llama-3.1-8B-swallow-code-v2-exp1-LR2.5e-5-WD0.1-iter0012500,,,0.124
```

`全体評価ではcd "$PBS_O_WORKDIR/LiveCodeBench"`を追加しています
